### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/venkatcloud2607/4fb6ad27-fea5-4e77-a742-22889fd9b25b/16a9c3bd-0041-4b0d-b0ab-e28db0365136/_apis/work/boardbadge/93e5243a-fad6-40d4-a083-dd7db1be3bbd)](https://dev.azure.com/venkatcloud2607/4fb6ad27-fea5-4e77-a742-22889fd9b25b/_boards/board/t/16a9c3bd-0041-4b0d-b0ab-e28db0365136/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/venkatcloud2607/4fb6ad27-fea5-4e77-a742-22889fd9b25b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.